### PR TITLE
Support for mock-port setting

### DIFF
--- a/src/main/scala/com/webtrends/harness/component/zookeeper/Curator.scala
+++ b/src/main/scala/com/webtrends/harness/component/zookeeper/Curator.scala
@@ -54,7 +54,6 @@ private[zookeeper] class Curator(settings: ZookeeperSettings) extends LoggingAda
       settings.connectionTimeout.intValue, new RetryNTimes(
         settings.retryCount,
         settings.retrySleep.intValue)))
-
     }
 
     internalClient.get

--- a/src/main/scala/com/webtrends/harness/component/zookeeper/NodeRegistration.scala
+++ b/src/main/scala/com/webtrends/harness/component/zookeeper/NodeRegistration.scala
@@ -73,10 +73,14 @@ trait NodeRegistration extends ZookeeperAdapter {
 
 
   private def getAddress: String = {
-    val host = if (address.host.isEmpty || address.host.get.equalsIgnoreCase("localhost") || address.host.get.equals("127.0.0.1")) {
+    val addrHost = address.host
+    val host = if (addrHost.isEmpty) {
+      InetAddress.getLocalHost.getCanonicalHostName
+    } else if (!Zookeeper.isMock(context.system.settings.config) &&
+      (addrHost.get.equalsIgnoreCase("localhost") || addrHost.get.equals("127.0.0.1"))) {
       InetAddress.getLocalHost.getCanonicalHostName
     } else {
-      address.host.get
+      addrHost.get
     }
 
     s"$host:$port"

--- a/src/main/scala/com/webtrends/harness/component/zookeeper/discoverable/DiscoverableCommandHelper.scala
+++ b/src/main/scala/com/webtrends/harness/component/zookeeper/discoverable/DiscoverableCommandHelper.scala
@@ -27,7 +27,7 @@ trait DiscoverableCommandHelper extends CommandHelper with Discoverable {
    * @return
    */
   def addDiscoverableCommandWithProps[T<:Command](name:String, props:Props, id:Option[String]=None) : Future[ActorRef] = {
-    implicit val timeout = Timeout(2 seconds)
+    implicit val timeout = Timeout(5 seconds)
     val idValue = id match {
       case Some(i) => i
       case None => UUID.randomUUID().toString
@@ -57,7 +57,7 @@ trait DiscoverableCommandHelper extends CommandHelper with Discoverable {
    * @param actorClass the class for the actor
    */
   def addDiscoverableCommand[T<:Command](name:String, actorClass:Class[T], id:Option[String]=None) : Future[ActorRef] = {
-    implicit val timeout = Timeout(2 seconds)
+    implicit val timeout = Timeout(5 seconds)
     val idValue = id match {
       case Some(i) => i
       case None => UUID.randomUUID().toString

--- a/src/test/scala/com/webtrends/harness/component/zookeeper/DiscoverableServiceSpec.scala
+++ b/src/test/scala/com/webtrends/harness/component/zookeeper/DiscoverableServiceSpec.scala
@@ -43,9 +43,9 @@ class DiscoverableServiceSpec
   implicit val system = ActorSystem("test", loadConfig)
 
   lazy val zkActor = system.actorOf(ZookeeperActor.props(ZookeeperSettings(system.settings.config)))
-  implicit val to = Timeout(2 seconds)
+  implicit val to = Timeout(5 seconds)
 
-  Await.result(zkActor ? Identify("xyz123"), 2 seconds)
+  Await.result(zkActor ? Identify("xyz123"), 5 seconds)
   lazy val service = DiscoverableService()
   Thread.sleep(5000)
   sequential

--- a/src/test/scala/com/webtrends/harness/component/zookeeper/ZookeeperServiceMockSpec.scala
+++ b/src/test/scala/com/webtrends/harness/component/zookeeper/ZookeeperServiceMockSpec.scala
@@ -17,13 +17,14 @@ class ZookeeperServiceMockSpec
       |wookiee-zookeeper {
       |  enabled = true
       |  mock-enabled = true
-      |  base-path="/test_path"
+      |  mock-port = 59595
+      |  base-path = "/test_path"
       |}
     """.stripMargin), None, None)
   implicit val system = TestHarness.system.get
   val service = ZookeeperService()
 
-  implicit val to = Timeout(2 seconds)
+  implicit val to = Timeout(5 seconds)
   val awaitResultTimeout = 5000 milliseconds
 
   sequential

--- a/src/test/scala/com/webtrends/harness/component/zookeeper/ZookeeperServiceSpec.scala
+++ b/src/test/scala/com/webtrends/harness/component/zookeeper/ZookeeperServiceSpec.scala
@@ -42,7 +42,7 @@ class ZookeeperServiceSpec
   val service = MockZookeeper(zkServer.getConnectString)
   val zkActor = ZookeeperService.getZkActor.get
 
-  implicit val to = Timeout(2 seconds)
+  implicit val to = Timeout(5 seconds)
   val awaitResultTimeout = 5000 milliseconds
 
   sequential


### PR DESCRIPTION
* Will attempt to connect to a ZK server on the specified port
* If failed, will spin up a new TestingServer
* Better host handling to make mocking safer