### PR TITLE
Kill ZookeeperService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <scala.artifact.version>2.11</scala.artifact.version>
         <scala.version>${scala.artifact.version}.12</scala.version>
         <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
-        <wookiee.core.version>1.3.18</wookiee.core.version>
+        <wookiee.core.version>1.3.20</wookiee.core.version>
     </properties>
 
     <groupId>com.webtrends</groupId>

--- a/src/main/scala/com/webtrends/harness/component/zookeeper/ZookeeperAdapter.scala
+++ b/src/main/scala/com/webtrends/harness/component/zookeeper/ZookeeperAdapter.scala
@@ -18,178 +18,166 @@
  */
 package com.webtrends.harness.component.zookeeper
 
-import akka.actor.Actor
+import java.util.concurrent.TimeUnit
+
+import akka.actor.{Actor, ActorSystem}
+import akka.pattern.ask
+import akka.util.Timeout
+import com.webtrends.harness.component.zookeeper.ZookeeperService._
+import com.webtrends.harness.logging.LoggingAdapter
 import org.apache.zookeeper.CreateMode
 
 import scala.concurrent.Future
 
-/**
- * @author Michael Cuthbert on 7/9/15.
- */
-trait ZookeeperAdapter {
+trait ZookeeperAdapter extends ZookeeperAdapterNonActor {
   this: Actor =>
+  override val zkActorSystem = this.context.system
+}
 
-  import this.context.system
+trait ZookeeperAdapterNonActor extends LoggingAdapter {
+  val zkActorSystem: ActorSystem
 
-  private lazy val zkService = ZookeeperService()
-
-  /**
-   * Set data in Zookeeper for the given path
-   * @param path the path to set data in
-   * @param data the data to set
-   * @param create should the node be created if it does not exist
-   * @param ephemeral should the created node be ephemeral
-   * @return the length of data that was written
-   */
-  def setData(path: String, data: Array[Byte], create: Boolean = false, ephemeral: Boolean = false)
-             (implicit timeout: akka.util.Timeout): Future[Int] = zkService.setData(path, data, create, ephemeral)
+  private[zookeeper] lazy val zkTimeout = Timeout(zkActorSystem.settings.config.getDuration(
+    s"${ZookeeperManager.ComponentName}.default-send-timeout", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
 
   /**
-   * Set data in Zookeeper for the given path async, does not return anything
-   * @param path the path to set data in
-   * @param data the data to set
-   * @param create should the node be created if it does not exist
-   * @param ephemeral should the created node be ephemeral
-   * @param namespace an optional name space
-   */
-  def setDataAsync(path: String, data: Array[Byte], create: Boolean = false, ephemeral: Boolean = false, namespace: Option[String] = None)
-                  (implicit timeout: akka.util.Timeout) =
-    zkService.setDataAsync(path, data, create, ephemeral, namespace)
+    * Set data in Zookeeper for the given path and optionally namespace
+    * @param path the path to set data in
+    * @param data the data to set
+    * @param create should the node be created if it does not exist
+    * @param ephemeral should the created node be ephemeral
+    * @param namespace the optional name space
+    * @return the length of data that was written
+    */
+  def setData(path: String,
+              data: Array[Byte],
+              create: Boolean = false,
+              ephemeral: Boolean = false,
+              namespace: Option[String] = None)
+             (implicit timeout: akka.util.Timeout): Future[Int] = {
+    (getMediator(zkActorSystem) ? SetPathData(path, data, create, ephemeral, namespace)).mapTo[Int]
+  }
 
   /**
-   * Set data in Zookeeper for the given path and namespace
-   * @param namespace the name space
-   * @param path the path to set data in
-   * @param data the data to set
-   * @param create should the node be created if it does not exist
-   * @param ephemeral should the created node be ephemeral
-   * @return the length of data that was written
-   */
-  def setDataWithNamespace(namespace: String, path: String, data: Array[Byte], create: Boolean = false, ephemeral: Boolean = false)
-                          (implicit timeout: akka.util.Timeout): Future[Int] = zkService.setData(path, data, create, ephemeral, Some(namespace))
+    * Set data in Zookeeper for the given path async, does not return anything
+    * @param path the path to set data in
+    * @param data the data to set
+    * @param create should the node be created if it does not exist
+    * @param ephemeral should the created node be ephemeral
+    * @param namespace an optional name space
+    */
+  def setDataAsync(path: String,
+                   data: Array[Byte],
+                   create: Boolean = false,
+                   ephemeral: Boolean = false,
+                   namespace: Option[String] = None)
+                  (implicit timeout: akka.util.Timeout): Unit =
+    getMediator(zkActorSystem) ! SetPathData(path, data, create, ephemeral, namespace, async = true)
 
   /**
-   * Get Zookeeper data for the given path
-   * @param path the path to get data from
-   * @return An instance of Array[Byte] or an empty array
-   */
-  def getData(path: String)(implicit timeout: akka.util.Timeout): Future[Array[Byte]] = zkService.getData(path)
+    * Get Zookeeper data for the given path
+    * @param path the path to get data from
+    * @param namespace the optional name space
+    * @return An instance of Array[Byte] or an empty array
+    */
+  def getData(path: String, namespace: Option[String] = None)(implicit timeout: akka.util.Timeout): Future[Array[Byte]] =
+    (getMediator(zkActorSystem) ? GetPathData(path, namespace)).mapTo[Array[Byte]]
 
   /**
-   * Get Zookeeper data for the given path
-   * @param namespace the name space
-   * @param path the path to get data from
-   * @return An instance of Array[Byte] or an empty array
-   */
-  def getDataWithNamespace(namespace: String, path: String)(implicit timeout: akka.util.Timeout): Future[Array[Byte]] =
-    zkService.getData(path, Some(namespace))
+    * Get the data in Zookeeper for the given path or set it if the path does not exist
+    * @param path the path to set data in
+    * @param data the data to set
+    * @param ephemeral should the created node be ephemeral
+    * @param namespace the optional name space
+    * @return An instance of Array[Byte] or an empty array
+    */
+  def getOrSetData(path: String,
+                   data: Array[Byte],
+                   ephemeral: Boolean = false,
+                   namespace: Option[String] = None)
+                  (implicit timeout: akka.util.Timeout): Future[Array[Byte]] =
+    (getMediator(zkActorSystem) ? GetOrSetPathData(path, data, ephemeral, namespace)).mapTo[Array[Byte]]
 
   /**
-   * Get the data in Zookeeper for the given path or set it if the path does not exist
-   * @param path the path to set data in
-   * @param data the data to set
-   * @param ephemeral should the created node be ephemeral
-   * @return An instance of Array[Byte] or an empty array
-   */
-  def getOrSetData(path: String, data: Array[Byte], ephemeral: Boolean = false)
-                  (implicit timeout: akka.util.Timeout): Future[Array[Byte]] = zkService.getOrSetData(path, data, ephemeral)
-
-  /**
-   * Get the data in Zookeeper for the given path or set it if the path does not exist
-   * @param namespace the name space
-   * @param path the path to set data in
-   * @param data the data to set
-   * @param ephemeral should the created node be ephemeral
-   * @return An instance of Array[Byte] or an empty array
-   */
-  def getOrSetDataWithNamespace(namespace: String, path: String, data: Array[Byte], ephemeral: Boolean = false)
-                               (implicit timeout: akka.util.Timeout): Future[Array[Byte]] = zkService.getOrSetData(path, data, ephemeral, Some(namespace))
-
-  /**
-   * Get the child nodes for the given path
-   * @param path the path to get the children of
-   * @param includeData should the children's data be returned. Defaults to false.
-   * @return A Seq[String] or Nil is an error occurs or if there no children
-   */
-  def getChildren(path: String, includeData: Boolean = false)
+    * Get the child nodes for the given path
+    * @param path the path to get the children of
+    * @param includeData should the children's data be returned. Defaults to false.
+    * @param namespace the optional name space
+    * @return A Seq[String] or Nil is an error occurs or if there no children
+    */
+  def getChildren(path: String, includeData: Boolean = false, namespace: Option[String] = None)
                  (implicit timeout: akka.util.Timeout): Future[Seq[(String, Option[Array[Byte]])]] =
-    zkService.getChildren(path, includeData)
+    (getMediator(zkActorSystem) ? GetPathChildren(path, includeData, namespace)).mapTo[Seq[(String, Option[Array[Byte]])]]
 
   /**
-   * Get the child nodes for the given path
-   * @param namespace the name space
-   * @param path the path to get the children of
-   * @param includeData should the children's data be returned. Defaults to false.
-   * @return A Seq[String] or Nil is an error occurs or if there no children
-   */
-  def getChildrenWithNamespace(namespace: String, path: String, includeData: Boolean = false)
-                              (implicit timeout: akka.util.Timeout): Future[Seq[(String, Option[Array[Byte]])]] =
-    zkService.getChildren(path, includeData, Some(namespace))
-
-  /**
-   * Does the node exist
-   * @param path the path to check
-   * @return true or false
-   */
-  def nodeExists(path: String)
+    * Does the node exist
+    * @param path the path to check
+    * @param namespace the optional name space
+    * @return true or false
+    */
+  def nodeExists(path: String, namespace: Option[String] = None)
                 (implicit timeout: akka.util.Timeout): Future[Boolean] =
-    zkService.nodeExists(path, None)
-
-  /**
-   * Does the node exist
-   * @param namespace the name space
-   * @param path the path to check
-   * @return true or false
-   */
-  def nodeExistsWithNamespace(namespace: String, path: String)
-                             (implicit timeout: akka.util.Timeout): Future[Boolean] =
-    zkService.nodeExists(path, Some(namespace))
+    (getMediator(zkActorSystem) ? GetNodeExists(path, namespace)).mapTo[Boolean]
 
   /**
     * Create a node at the given path
     * @param path the path to create the node at
     * @param ephemeral is this node ephemeral
     * @param data the data to set in the node
+    * @param namespace the optional name space
     * @return the full path to the newly created node
     */
-  def createNode(path: String, ephemeral: Boolean, data: Option[Array[Byte]])
-                (implicit timeout: akka.util.Timeout): Future[String] = zkService.createNode(path, ephemeral, data)
+  def createNode(path: String,
+                 ephemeral: Boolean,
+                 data: Option[Array[Byte]],
+                 namespace: Option[String] = None)
+                (implicit timeout: akka.util.Timeout): Future[String] = {
+    val mode = if (ephemeral) CreateMode.EPHEMERAL else CreateMode.PERSISTENT
+    (getMediator(zkActorSystem) ? CreateNode(path, mode, data, namespace)).mapTo[String]
+  }
 
   /**
-   * Create a node at the given path
-   * @param path the path to create the node at
-   * @param createMode mode in which to create the node
-   * @param data the data to set in the node
-   * @return the full path to the newly created node
-   */
-  def createNode(path: String, createMode: CreateMode, data: Option[Array[Byte]])
-                (implicit timeout: akka.util.Timeout): Future[String] = zkService.createNodeWithMode(path, createMode, data)
+    * Create a node at the given path
+    * @param path the path to create the node at
+    * @param createMode mode in which to create the node
+    * @param data the data to set in the node
+    * @return the full path to the newly created node
+    */
+  def createNode(path: String,
+                 createMode: CreateMode,
+                 data: Option[Array[Byte]])
+                (implicit timeout: akka.util.Timeout): Future[String] =
+    (getMediator(zkActorSystem) ? CreateNode(path, createMode, data)).mapTo[String]
 
   /**
-   * Create a node at the given path
-   * @param namespace the name space
-   * @param path the path to create the node at
-   * @param ephemeral is the node ephemeral
-   * @param data the data to set in the node
-   * @return the full path to the newly created node
-   */
-  def createNodeWithNamespace(namespace: String, path: String, ephemeral: Boolean, data: Option[Array[Byte]])
-                             (implicit timeout: akka.util.Timeout): Future[String] = zkService.createNode(path, ephemeral, data, Some(namespace))
+    * Create a node at the given path
+    * @param path the path to create the node at
+    * @param createMode mode in which to create the node
+    * @param data the data to set in the node
+    * @param namespace the optional name space
+    * @return the full path to the newly created node
+    */
+  def createNodeWithNamespace(path: String,
+                 createMode: CreateMode,
+                 data: Option[Array[Byte]],
+                 namespace: Option[String] = None)
+                (implicit timeout: akka.util.Timeout): Future[String] =
+    (getMediator(zkActorSystem) ? CreateNode(path, createMode, data, namespace)).mapTo[String]
 
   /**
-   * Delete a node at the given path
-   * @param path the path to create the node at
-   * @return the full path to the newly created node
-   */
-  def deleteNode(path: String)
-                (implicit timeout: akka.util.Timeout): Future[String] = zkService.deleteNode(path)
+    * Delete a node at the given path
+    * @param path the path to create the node at
+    * @param namespace the optional name space
+    * @return the full path to the newly created node
+    */
+  def deleteNode(path: String, namespace: Option[String] = None)
+                (implicit timeout: akka.util.Timeout): Future[String] =
+    (getMediator(zkActorSystem) ? DeleteNode(path, namespace)).mapTo[String]
 
   /**
-   * Delete a node at the given path
-   * @param namespace the name space
-   * @param path the path to delete the node at
-   * @return the full path to the newly created node
-   */
-  def deleteNodeWithNamespace(namespace: String, path: String)
-                             (implicit timeout: akka.util.Timeout): Future[String] = zkService.deleteNode(path, Some(namespace))
+    * Stops the zookeeper mediator (ZookeeperActor) associated with this system
+    */
+  def stopZookeeper(): Unit = {
+    ZookeeperService.unregisterMediator(zkActorSystem)
+  }
 }

--- a/src/main/scala/com/webtrends/harness/component/zookeeper/ZookeeperEvent.scala
+++ b/src/main/scala/com/webtrends/harness/component/zookeeper/ZookeeperEvent.scala
@@ -19,6 +19,8 @@
 package com.webtrends.harness.component.zookeeper
 
 import akka.actor.{Actor, ActorRef}
+import com.webtrends.harness.component.zookeeper.ZookeeperEvent.Internal.{RegisterZookeeperEvent, UnregisterZookeeperEvent}
+import com.webtrends.harness.component.zookeeper.ZookeeperService.getMediator
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent
 import org.apache.curator.framework.state.ConnectionState
 
@@ -90,19 +92,19 @@ trait ZookeeperEventAdapter {
   import ZookeeperEvent.ZookeeperEventRegistration
   import context.system
 
-  private lazy val zkEventService = ZookeeperService()
-
   /**
    * Register for Zookeeper events.
    * @param registrar the actor that is to receive the events
    * @param to the class to register for
    */
-  def register(registrar: ActorRef, to: ZookeeperEventRegistration): Unit = zkEventService.register(registrar, to)
+  def register(registrar: ActorRef, to: ZookeeperEventRegistration): Unit =
+    getMediator(system) ! RegisterZookeeperEvent(registrar, to)
 
   /**
    * Unregister for Zookeeper events.
    * @param registrar the actor that is to receive the events
    * @param to the class to register for
    */
-  def unregister(registrar: ActorRef, to: ZookeeperEventRegistration): Unit = zkEventService.unregister(registrar, to)
+  def unregister(registrar: ActorRef, to: ZookeeperEventRegistration): Unit =
+    getMediator(system) ! UnregisterZookeeperEvent(registrar, to)
 }

--- a/src/main/scala/com/webtrends/harness/component/zookeeper/ZookeeperManager.scala
+++ b/src/main/scala/com/webtrends/harness/component/zookeeper/ZookeeperManager.scala
@@ -24,13 +24,14 @@ import com.webtrends.harness.component.zookeeper.discoverable.typed.Discoverable
 class ZookeeperManager(name:String) extends Component(name) with Zookeeper {
   override protected def defaultChildName: Option[String] = Some(Zookeeper.ZookeeperName)
 
-  /**
-   * Starts the component
-   */
-  override def start = {
-    log.info("Starting Zookeeper Component...")
-    startZookeeper()
-    super.start
+  override def preStart() = {
+    if (!isClusterEnabled()) {
+      log.info("Starting Zookeeper Component...")
+      startZookeeper()
+    } else {
+      log.info("Zookeeper Component Started, but letting wookiee-cluster start its actors...")
+    }
+    super.preStart()
   }
 
   override def systemReady(): Unit = {

--- a/src/main/scala/com/webtrends/harness/component/zookeeper/mock/MockZookeeper.scala
+++ b/src/main/scala/com/webtrends/harness/component/zookeeper/mock/MockZookeeper.scala
@@ -23,32 +23,41 @@ import akka.actor.{ActorSystem, PoisonPill, Props}
 import akka.util.Timeout
 import com.typesafe.config.Config
 import com.webtrends.harness.component.zookeeper.config.ZookeeperSettings
-import com.webtrends.harness.component.zookeeper.{ZookeeperActor, ZookeeperService}
+import com.webtrends.harness.component.zookeeper.{ZookeeperActor, ZookeeperAdapterNonActor, ZookeeperService}
 import com.webtrends.harness.utils.ActorWaitHelper
 
 import scala.concurrent.duration._
 
 /**
-  * Use this actor to spin up a local zookeeper for unit testing.
+  * Use this object to spin up a local zookeeper for unit testing.
   * Requires org.apache.curator:curator-test
-  * To use ZK service from a test class:
+  * To use ZK service from a test class execute this code before anything:
   * val zkServer = new TestingServer()
-  * implicit val system = ActorSystem("test")
+  * implicit val system = ActorSystem("SomeTest")
   * lazy val zkService = MockZookeeper(zkServer.getConnectString)
   *
   * Now you should be able to call ZK state changing methods in zkService (ZookeeperService.scala).
   * Note: The clusterEnabled flag exists to support wookiee-cluster
   */
 object MockZookeeper {
-  private[harness] def props(settings:ZookeeperSettings, clusterEnabled: Boolean = false)(implicit system: ActorSystem): Props =
-    Props(classOf[TestZookeeperActor], settings, clusterEnabled)
+  case class MockZookeeper(override val zkActorSystem: ActorSystem) extends ZookeeperAdapterNonActor
 
-  def apply(zkSettings: ZookeeperSettings, clusterEnabled: Boolean = false)(implicit system: ActorSystem): ZookeeperService = {
-    ActorWaitHelper.awaitActor(props(zkSettings, clusterEnabled), system)(Timeout(15 seconds))
-    ZookeeperService()
+  private[harness] def props(settings:ZookeeperSettings, clusterEnabled: Boolean = false)(implicit system: ActorSystem): Props =
+    Props(classOf[ZookeeperActor], settings, clusterEnabled)
+
+  // Only zkSettings is required
+  def apply(zkSettings: ZookeeperSettings, clusterEnabled: Boolean = false,
+            actorName: Option[String] = None)(implicit system: ActorSystem): ZookeeperAdapterNonActor = {
+    val zkActor = if (actorName.isDefined) {
+      system.actorOf(props(zkSettings, clusterEnabled), actorName.get)
+    } else system.actorOf(props(zkSettings, clusterEnabled))
+
+    ActorWaitHelper.awaitActorRef(zkActor, system)(Timeout(15 seconds))
+    MockZookeeper(system)
   }
 
-  def apply(config: Config)(implicit system: ActorSystem): ZookeeperService = {
+  def apply(config: Config)
+           (implicit system: ActorSystem): ZookeeperAdapterNonActor = {
     apply(if (system.settings.config.hasPath("wookiee-zookeeper")) {
       ZookeeperSettings(system.settings.config.getConfig("wookiee-zookeeper"))
     } else {
@@ -56,32 +65,24 @@ object MockZookeeper {
     })
   }
 
-  def apply(zookeeperQuorum: String)(implicit system: ActorSystem): ZookeeperService = {
+  def apply(zookeeperQuorum: String)(implicit system: ActorSystem): ZookeeperAdapterNonActor = {
     apply(getTestConfig(zookeeperQuorum))
+  }
+
+  def getTestConfig(config: Config)(implicit system: ActorSystem): ZookeeperSettings = {
+    ZookeeperSettings(config)
   }
 
   def getTestConfig(zookeeperQuorum: String)(implicit system: ActorSystem): ZookeeperSettings = {
     if (!zookeeperQuorum.isEmpty) {
       ZookeeperSettings("test", "pod", zookeeperQuorum)
-    } else if (system.settings.config.hasPath("wookiee-zookeeper")) {
-      ZookeeperSettings(system.settings.config.getConfig("wookiee-zookeeper"))
     } else {
       ZookeeperSettings(system.settings.config)
     }
   }
 
-  def stop(): Unit = {
+  def stop(implicit system: ActorSystem): Unit = {
     ZookeeperService.getZkActor.foreach(_ ! PoisonPill)
   }
 }
 
-case class GetSetWeightInterval()
-
-class TestZookeeperActor(settings: ZookeeperSettings, clusterEnabled: Boolean = false)
-  extends ZookeeperActor(settings, clusterEnabled) {
-  override def processing: Receive = ( {
-    case GetSetWeightInterval => sender() ! setWeightInterval
-  }: Receive) orElse super.processing
-
-  log.info(s"Create the TestZookeeperActor and attaching to Zookeeper at ${settings.quorum}")
-}

--- a/src/test/scala/com/webtrends/harness/component/zookeeper/NodeRegistrationSpec.scala
+++ b/src/test/scala/com/webtrends/harness/component/zookeeper/NodeRegistrationSpec.scala
@@ -1,0 +1,32 @@
+package com.webtrends.harness.component.zookeeper
+
+import org.specs2.mutable.SpecificationWithJUnit
+import NodeRegistration._
+import com.webtrends.harness.service.test.config.TestConfig
+
+class NodeRegistrationSpec extends SpecificationWithJUnit {
+  "NodeRegistration" should {
+    "get base path from config" in {
+      val bp = getBasePath(testConf)
+      bp mustEqual "/base-path/tdc_tp/1.1"
+    }
+
+    "get base path from cluster config" in {
+      val bp = getBasePath(testConf.withFallback(
+        TestConfig.conf("wookiee-cluster.base-path = /cluster-path")))
+      bp mustEqual "/cluster-path/tdc_tp/1.1"
+    }
+  }
+
+  def testConf = {
+    TestConfig.conf(
+      """
+        |wookiee-zookeeper {
+        | quorum = "fake"
+        | base-path = "/base-path"
+        | datacenter = "tdc"
+        | pod = "tp"
+        |}
+      """.stripMargin)
+  }
+}

--- a/src/test/scala/com/webtrends/harness/component/zookeeper/ZookeeperServiceMockSpec.scala
+++ b/src/test/scala/com/webtrends/harness/component/zookeeper/ZookeeperServiceMockSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class ZookeeperServiceMockSpec
-  extends SpecificationWithJUnit {
+  extends SpecificationWithJUnit with ZookeeperAdapterNonActor {
 
   val testHarness = TestHarness(ConfigFactory.parseString(
     """
@@ -21,8 +21,7 @@ class ZookeeperServiceMockSpec
       |  base-path = "/test_path"
       |}
     """.stripMargin), None, None)
-  implicit val system = TestHarness.system.get
-  val service = ZookeeperService()
+  override implicit val zkActorSystem = TestHarness.system.get
 
   implicit val to = Timeout(5 seconds)
   val awaitResultTimeout = 5000 milliseconds
@@ -31,68 +30,68 @@ class ZookeeperServiceMockSpec
 
   "The zookeeper service" should {
     "allow callers to create a node for a valid path" in {
-      val res = Await.result(service.createNode("/test", ephemeral = false, Some("data".getBytes)), awaitResultTimeout)
+      val res = Await.result(createNode("/test", ephemeral = false, Some("data".getBytes)), awaitResultTimeout)
       res shouldEqual "/test"
     }
 
     "allow callers to create a node for a valid namespace and path" in {
-      val res = Await.result(service.createNode("/namespacetest", ephemeral = false, Some("namespacedata".getBytes), Some("space")), awaitResultTimeout)
+      val res = Await.result(createNode("/namespacetest", ephemeral = false, Some("namespacedata".getBytes), Some("space")), awaitResultTimeout)
       res shouldEqual "/namespacetest"
     }
 
     "allow callers to delete a node for a valid path" in {
-      val res = Await.result(service.createNode("/deleteTest", ephemeral = false, Some("data".getBytes)), awaitResultTimeout)
+      val res = Await.result(createNode("/deleteTest", ephemeral = false, Some("data".getBytes)), awaitResultTimeout)
       res shouldEqual "/deleteTest"
-      val res2 = Await.result(service.deleteNode("/deleteTest"), awaitResultTimeout)
+      val res2 = Await.result(deleteNode("/deleteTest"), awaitResultTimeout)
       res2 shouldEqual "/deleteTest"
     }
 
     "allow callers to delete a node for a valid namespace and path " in {
-      val res = Await.result(service.createNode("/deleteTest", ephemeral = false, Some("data".getBytes), Some("space")), awaitResultTimeout)
+      val res = Await.result(createNode("/deleteTest", ephemeral = false, Some("data".getBytes), Some("space")), awaitResultTimeout)
       res shouldEqual "/deleteTest"
-      val res2 = Await.result(service.deleteNode("/deleteTest", Some("space")), awaitResultTimeout)
+      val res2 = Await.result(deleteNode("/deleteTest", Some("space")), awaitResultTimeout)
       res2 shouldEqual "/deleteTest"
     }
 
     "allow callers to get data for a valid path " in {
-      val res = Await.result(service.getData("/test"), awaitResultTimeout)
+      val res = Await.result(getData("/test"), awaitResultTimeout)
       new String(res) shouldEqual "data"
     }
 
     "allow callers to get data for a valid namespace and path " in {
-      val res = Await.result(service.getData("/namespacetest", Some("space")), awaitResultTimeout)
+      val res = Await.result(getData("/namespacetest", Some("space")), awaitResultTimeout)
       new String(res) shouldEqual "namespacedata"
     }
 
     " allow callers to get data for a valid path with a namespace" in {
-      val res = Await.result(service.getData("/namespacetest", Some("space")), awaitResultTimeout)
+      val res = Await.result(getData("/namespacetest", Some("space")), awaitResultTimeout)
       new String(res) shouldEqual "namespacedata"
     }
 
     " return an error when getting data for an invalid path " in {
-      Await.result(service.getData("/testbad"), awaitResultTimeout) must throwA[Exception]
+      Await.result(getData("/testbad"), awaitResultTimeout) must throwA[Exception]
     }
 
     " allow callers to get children with no data for a valid path " in {
-      Await.result(service.createNode("/test/child", ephemeral = false, None), awaitResultTimeout)
-      val res2 = Await.result(service.getChildren("/test"), awaitResultTimeout)
+      Await.result(createNode("/test/child", ephemeral = false, None), awaitResultTimeout)
+      val res2 = Await.result(getChildren("/test"), awaitResultTimeout)
       res2.head._1 shouldEqual "child"
       res2.head._2 shouldEqual None
     }
 
     " allow callers to get children with data for a valid path " in {
-      Await.result(service.setData("/test/child", "data".getBytes), awaitResultTimeout)
-      val res2 = Await.result(service.getChildren("/test", includeData = true), awaitResultTimeout)
+      Await.result(setData("/test/child", "data".getBytes), awaitResultTimeout)
+      val res2 = Await.result(getChildren("/test", includeData = true), awaitResultTimeout)
       res2.head._1 shouldEqual "child"
       res2.head._2.get shouldEqual "data".getBytes
     }
 
     " return an error when getting children for an invalid path " in {
-      Await.result(service.getChildren("/testbad"), awaitResultTimeout) must throwA[Exception]
+      Await.result(getChildren("/testbad"), awaitResultTimeout) must throwA[Exception]
     }
   }
 
   step {
-    TestKit.shutdownActorSystem(system)
+    TestKit.shutdownActorSystem(zkActorSystem)
   }
 }

--- a/src/test/scala/com/webtrends/harness/component/zookeeper/ZookeeperServiceSpec.scala
+++ b/src/test/scala/com/webtrends/harness/component/zookeeper/ZookeeperServiceSpec.scala
@@ -25,8 +25,9 @@ import akka.pattern.ask
 import akka.testkit.TestKit
 import akka.util.Timeout
 import com.typesafe.config.{Config, ConfigFactory}
+import com.webtrends.harness.component.zookeeper.ZookeeperActor.GetSetWeightInterval
 import com.webtrends.harness.component.zookeeper.discoverable.DiscoverableService.{MakeDiscoverable, QueryForInstances, UpdateWeight}
-import com.webtrends.harness.component.zookeeper.mock.{GetSetWeightInterval, MockZookeeper}
+import com.webtrends.harness.component.zookeeper.mock.MockZookeeper
 import org.apache.curator.test.TestingServer
 import org.apache.curator.x.discovery.{ServiceInstance, UriSpec}
 import org.specs2.mutable.SpecificationWithJUnit
@@ -185,7 +186,7 @@ class ZookeeperServiceSpec
     }
 
     "use set weight interval defined in config" in {
-      Await.result(zkActor ? GetSetWeightInterval, 3 second).asInstanceOf[Long] mustEqual 2
+      Await.result(zkActor ? GetSetWeightInterval(), 3 second).asInstanceOf[Long] mustEqual 2
     }
   }
 


### PR DESCRIPTION
* Mock improvements and added convenience methods
* Move initial node creation off of NodeRegistration and into ZKActor
* Don't start two ZKActors when wookiee-cluster is included
* ZKAdapter now skips the service, and can be applied to non-actors
* ZK Actors now register to the actor system they are on, makes it way less likely for tests to clash
